### PR TITLE
Removed the medaitor list page regex

### DIFF
--- a/src/pages/mediator-library.js
+++ b/src/pages/mediator-library.js
@@ -10,7 +10,7 @@ function MediatorDetails(props) {
     <div className="card card_box_shadow margin-2em-y">
       <div className="card__header card_header_color">
         <h2 className="subtitle">
-          {/openhim-mediator-(.*?)(?:\s|$)/g.exec(props.data.name)[1]}
+          {props.data.name}
         </h2>
       </div>
       <div className="card__body">


### PR DESCRIPTION
The regex was causing a failure due to how certain repos are named using "openhim-mediator".
We expect this to be the start of the repo name but some repos have this naming in the middle. Our Regex therefor doesnt return a value we require to display to the user and causes it to break