### PR TITLE
remove extra injection of google analytics plugin

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -119,5 +119,5 @@ module.exports = {
       },
     ],
   ],
-  plugins: ['docusaurus-image-loader', '@docusaurus/plugin-google-analytics']
+  plugins: ['docusaurus-image-loader']
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@docusaurus/core": "^2.0.0-alpha.70",
-    "@docusaurus/plugin-google-analytics": "^2.0.0-alpha.70",
     "@docusaurus/preset-classic": "^2.0.0-alpha.70",
     "axios": "^0.21.1",
     "classnames": "^2.2.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1281,7 +1281,7 @@
     "@docusaurus/utils" "2.0.0-alpha.70"
     react-json-view "^1.19.1"
 
-"@docusaurus/plugin-google-analytics@2.0.0-alpha.70", "@docusaurus/plugin-google-analytics@^2.0.0-alpha.70":
+"@docusaurus/plugin-google-analytics@2.0.0-alpha.70":
   version "2.0.0-alpha.70"
   resolved "https://registry.yarnpkg.com/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.0.0-alpha.70.tgz#9476314353d585716cbdd408319ff30bdbda4f87"
   integrity sha512-Ah9W83ZnA0VvmflKNuGq5f/CaEjWJxhjkISQn09/ykEvXfWV33000Bhck4RoCr5YxD+GBEBT5suG5LKH7Qkigw==


### PR DESCRIPTION
The google analytics plugin was being instantiated ttwice with same id and this was causing the production (build) deployment to fail. Using the @docasaurus classic preset with the googleAnalytics themeConfig installs the googleAnalytic plugin. The direct installation of the analytics plugin that was being done has been removed